### PR TITLE
v1.3.0: Compatibility with Nov 4th 2025 base game patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj
 /.idea
 /out
 /thunderstore/build
+/.vs

--- a/NineSolsAPI/NineSolsAPI.csproj
+++ b/NineSolsAPI/NineSolsAPI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Version>1.2.3</Version>
         <Authors>jakobhellermann@protonmail.com</Authors>
@@ -81,9 +81,7 @@
         <ItemGroup>
             <MissingReferences Include="@(Reference)" Condition="!Exists('%(Reference.HintPath)')" />
         </ItemGroup>
-        <Error Condition="@(MissingReferences->Count()) > 0" Text="Missing reference(s);
-@(MissingReferences->'%(HintPath)', ',&#x0A;')
-Did you forget to adjust your NineSolsPath '$(DllPath)'?" />
+        <Error Condition="@(MissingReferences-&gt;Count()) &gt; 0" Text="Missing reference(s);&#xD;&#xA;@(MissingReferences->'%(HintPath)', ',&#xA;')&#xD;&#xA;Did you forget to adjust your NineSolsPath '$(DllPath)'?" />
     </Target>
 
     <Target Name="CopyMod" AfterTargets="PostBuildEvent" Condition="'$(CopyDir)' != ''">

--- a/NineSolsAPI/NineSolsAPI.csproj
+++ b/NineSolsAPI/NineSolsAPI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <Version>1.2.3</Version>
+        <Version>1.3.0</Version>
         <Authors>jakobhellermann@protonmail.com</Authors>
         <RepositoryUrl>https://github.com/nine-sols-modding/NineSolsAPI</RepositoryUrl>
         <Description>Nine Sols Modding API</Description>

--- a/NineSolsAPI/NineSolsAPI.csproj
+++ b/NineSolsAPI/NineSolsAPI.csproj
@@ -33,7 +33,7 @@
     <ItemGroup>
         <PackageReference Include="BepInEx.Analyzers" Version="1.0.8" />
 
-        <PackageReference Include="BepInEx.Core" Version="5.4.19" IncludeAssets="compile" />
+        <PackageReference Include="BepInEx.Core" Version="5.4.21" IncludeAssets="compile" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
         <PackageReference Include="UnityEngine.Modules" Version="2022.3.18" IncludeAssets="compile" />
 

--- a/NineSolsAPI/NineSolsAPI.csproj
+++ b/NineSolsAPI/NineSolsAPI.csproj
@@ -35,7 +35,7 @@
 
         <PackageReference Include="BepInEx.Core" Version="5.4.21" IncludeAssets="compile" />
         <PackageReference Include="BepInEx.PluginInfoProps" Version="2.*" />
-        <PackageReference Include="UnityEngine.Modules" Version="2022.3.18" IncludeAssets="compile" />
+        <PackageReference Include="UnityEngine.Modules" Version="2022.3.62" IncludeAssets="compile" />
 
         <!--<PackageReference Include="NineSols.GameLibs" Version="" /> -->
         <!-- GAME LIBS -->

--- a/NineSolsAPI/NineSolsAPICore.cs
+++ b/NineSolsAPI/NineSolsAPICore.cs
@@ -44,6 +44,11 @@ public class NineSolsAPICore : BaseUnityPlugin {
         Instance = this;
         Log.Init(Logger);
 
+        // Required since the Nov 4th 2025 base game patch. Without this, the BepInExManager object gets unloaded during wakeup,
+        // causing all mods the player "loaded" to be immediately unloaded and thus never actually modify the game.
+        var bepinexManagerObject = this.gameObject;
+        bepinexManagerObject.hideFlags = HideFlags.HideAndDontSave;
+
         // it's unclear when bepinex registers this itself, we've run into bugs here
         if (!TomlTypeConverter.CanConvert(typeof(KeyboardShortcut))) {
             TomlTypeConverter.AddConverter(typeof(KeyboardShortcut),
@@ -114,6 +119,7 @@ public class NineSolsAPICore : BaseUnityPlugin {
 
     private Canvas CreateFullscreenCanvas() {
         var fullscreenCanvasObject = new GameObject("NineSolsAPI-FullscreenCanvas");
+        fullscreenCanvasObject.hideFlags = HideFlags.HideAndDontSave; // required to keep this object alive since the Nov 4th 2025 base game patch
         var theFullscreenCanvas = fullscreenCanvasObject.AddComponent<Canvas>();
         theFullscreenCanvas.renderMode = RenderMode.ScreenSpaceOverlay;
 

--- a/thunderstore/thunderstore.toml
+++ b/thunderstore/thunderstore.toml
@@ -4,7 +4,7 @@ schemaVersion = "0.0.1"
 [package]
 namespace = "ninesolsmodding"
 name = "NineSolsAPI"
-versionNumber = "1.2.3"
+versionNumber = "1.3.0"
 description = "Modding API for Nine Sols"
 websiteUrl = "https://github.com/nine-sols-modding/NineSolsAPI"
 containsNsfwContent = false


### PR DESCRIPTION
Since this is my first time touching NineSolsAPI, and in a particularly dangerous way, I'm being as paranoid as I know how to be: I've already applied a similar HideAndDontSave hack [in my own Archipelago Randomizer mod](https://github.com/Ixrec/NineSolsArchipelagoRandomizer/commit/786fc4e3ac857c234f5ab746a2aa84fb9af262b0) (thanks Literature for figuring this out), and my randomizer players are saying it now works fine on current patch. So I'm opening this PR to document what I plan to try merging in the near future. If no one objects to it, I'll probably merge it this weekend, and we'll see if the auto-deployment works.